### PR TITLE
Spelling mistake

### DIFF
--- a/app/config/rules/bs_golden.json
+++ b/app/config/rules/bs_golden.json
@@ -34,7 +34,7 @@
 			]
 		},
 		{
-			"title": "No Self-Antagging or Greif",
+			"title": "No Self-Antagging or Grief",
 			"clauses": [
 				"Self-antagging includes damaging the station, attacking other players without a valid reason, and subverting the established chain of command as a non-antagonist role.",
 				"Griefing includes intentionally ruining the game by abusing ingame mechanics (exploits, force crashes/lag, spamming shuttle delay, ect.)",


### PR DESCRIPTION
Spells grief correctly