### PR TITLE
patreon goals that scale with our income

### DIFF
--- a/app/config/website.yml
+++ b/app/config/website.yml
@@ -1,4 +1,4 @@
-patreon-goal: 12500
+patreon-goals: [12500, 20000] # Once one goal is met it will change to the next
 items-per-page: 30
 
 static-url-path: "/static"

--- a/app/modules/api/controllers.py
+++ b/app/modules/api/controllers.py
@@ -39,7 +39,7 @@ def page_api_stats_totals():
 def page_api_budget():
 	income = util.get_patreon_income()
 
-	current_goal = max(goal for goal in cfg.WEBSITE['patreon-goals'] if goal > income) # Find the lowest goal we haven't passed
+	current_goal = min([goal for goal in cfg.WEBSITE['patreon-goals'] if goal > income] or (max(cfg.WEBSITE['patreon-goals']),)) # Find the lowest goal we haven't passed
 
 	budget_stats = {
 		"income": round(income/100, 2),

--- a/app/modules/api/controllers.py
+++ b/app/modules/api/controllers.py
@@ -38,10 +38,13 @@ def page_api_stats_totals():
 @bp_api.route("/budget")
 def page_api_budget():
 	income = util.get_patreon_income()
+
+	current_goal = max(goal for goal in cfg.WEBSITE['patreon-goals'] if goal > income) # Find the lowest goal we haven't passed
+
 	budget_stats = {
 		"income": round(income/100, 2),
-		"goal": round(cfg.WEBSITE['patreon-goal']/100, 2),
-		"percent": int(income/cfg.WEBSITE['patreon-goal']*100)
+		"goal": round(current_goal/100, 2),
+		"percent": int(income/current_goal*100)
 	}
 	return jsonify(budget_stats)
 


### PR DESCRIPTION
Closes #17 as it is redundant

Makes it so Patreon goals switch with how much income we are already getting. If we are reaching a certain goal, switch to the next lowest one.