### PR TITLE
Resolves ValueError runtime in the /budget route of the api

### DIFF
--- a/app/modules/api/controllers.py
+++ b/app/modules/api/controllers.py
@@ -39,7 +39,7 @@ def page_api_stats_totals():
 def page_api_budget():
 	income = util.get_patreon_income()
 
-	current_goal = min((goal for goal in cfg.WEBSITE['patreon-goals'] if goal > income) or (max(cfg.WEBSITE['patreon-goals']),)) # Find the lowest goal we haven't passed
+	current_goal = min([goal for goal in cfg.WEBSITE['patreon-goals'] if goal > income] or (max(cfg.WEBSITE['patreon-goals']),)) # Find the lowest goal we haven't passed
 
 	budget_stats = {
 		"income": round(income/100, 2),


### PR DESCRIPTION
Reverts the generator changes to resolve ValueError runtimes caused by our income being higher than any current goals.

~~I also really didn't want to touch this any more than I had to~~