### PR TITLE
Adds APM support

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,6 +7,10 @@ services:
       - ./src:/beesite:ro
     environment:
       DEBUG: 'True'
+      APM: 'False' #Set to True to enable APM logging
+      APM_URL: 'http://0.0.0.0:8200'
+      APM_DEBUG: 'True'
+      APM_TOKEN: '' #Leave empty if you aren't using a token
     networks:
       main:
         aliases:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,6 +6,11 @@ services:
     image: beestation/beesite
     volumes:
       - ./config/site-settings:/beesite/app/config:ro
+    environment:
+      APM: 'False' #Set to True to enable APM logging
+      APM_URL: 'http://0.0.0.0:8200'
+      APM_DEBUG: 'False'
+      APM_TOKEN: '' #Leave empty if you aren't using a token
     networks:
       main:
         aliases:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ cachetools==4.0.0
 flask==1.1.1
 flask-cors==3.0.8
 
+elastic-apm[flask]==5.10.0
+
 requests==2.23.0
 
 mysqlclient==1.4.6

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -11,13 +11,13 @@ from os import environ
 
 app = Flask(__name__, static_url_path=cfg.WEBSITE["static-url-path"])
 
-if 'DEBUG' in environ and environ['DEBUG'] == "True":
+if environ.get("DEBUG") == "True":
 	from werkzeug.debug import DebuggedApplication
 	app.wsgi_app = DebuggedApplication(app.wsgi_app, True)
 
 	app.debug = True
 
-if 'APM' in environ and environ['APM'] == "True":
+if environ.get("APM") == "True":
 	from elasticapm.contrib.flask import ElasticAPM
 
 	apm_url = "http://0.0.0.0:8200"
@@ -44,7 +44,7 @@ if 'APM' in environ and environ['APM'] == "True":
 		'SERVER_URL': apm_url,
 
 		'DEBUG': apm_debug,
-		}
+	}
 
 	apm = ElasticAPM(app)
 

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -11,11 +11,47 @@ from os import environ
 
 app = Flask(__name__, static_url_path=cfg.WEBSITE["static-url-path"])
 
-if 'DEBUG' in environ:
+if 'DEBUG' in environ and environ['DEBUG'] == "True":
 	from werkzeug.debug import DebuggedApplication
 	app.wsgi_app = DebuggedApplication(app.wsgi_app, True)
 
 	app.debug = True
+
+if 'APM' in environ and environ['APM'] == "True":
+	from elasticapm.contrib.flask import ElasticAPM
+
+	# Check for APM envrion variables
+	if 'APM_URL' in environ:
+		apm_url = environ['APM_URL']
+	else:
+		apm_url = "http://0.0.0.0:8200"
+
+	if 'APM_DEBUG' in environ:
+		apm_debug = environ['APM_DEBUG']
+	else:
+		apm_debug = False
+
+	if 'APM_TOKEN' in environ:
+		apm_token = environ['APM_TOKEN']
+	else:
+		apm_token = ''
+
+
+	app.config['ELASTIC_APM'] = {
+		# Set required service name. Allowed characters:
+		# a-z, A-Z, 0-9, -, _, and space
+		'SERVICE_NAME': 'beesite',
+
+		# Use if APM Server requires a token
+		'SECRET_TOKEN': apm_token,
+
+		# Set custom APM Server URL (default: http://0.0.0.0:8200)
+		'SERVER_URL': apm_url,
+
+		'DEBUG': apm_debug,
+		}
+
+	apm = ElasticAPM(app)
 
 app.url_map.strict_slashes = False
 

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -20,22 +20,17 @@ if 'DEBUG' in environ and environ['DEBUG'] == "True":
 if 'APM' in environ and environ['APM'] == "True":
 	from elasticapm.contrib.flask import ElasticAPM
 
+	apm_url = "http://0.0.0.0:8200"
+	apm_debug = False
+	apm_token = ''
+
 	# Check for APM envrion variables
 	if 'APM_URL' in environ:
 		apm_url = environ['APM_URL']
-	else:
-		apm_url = "http://0.0.0.0:8200"
-
 	if 'APM_DEBUG' in environ:
 		apm_debug = environ['APM_DEBUG']
-	else:
-		apm_debug = False
-
 	if 'APM_TOKEN' in environ:
 		apm_token = environ['APM_TOKEN']
-	else:
-		apm_token = ''
-
 
 	app.config['ELASTIC_APM'] = {
 		# Set required service name. Allowed characters:


### PR DESCRIPTION
Adds support for Elastic's APM reporting.

In order to enable APM, four environmental variables should be set, preferably within the docker-compose file.

```yml
APM: 'False' #Set to True to enable APM logging
APM_URL: 'http://0.0.0.0:8200'
APM_DEBUG: 'True'
APM_TOKEN: '' #Leave empty if you aren't using a token
```

