### PR TITLE
Updates the patreon package to 0.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.8-slim-buster
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3-dev default-libmysqlclient-dev build-essential
+    apt-get install -y --no-install-recommends python3-dev default-libmysqlclient-dev build-essential git
 
 # Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -14,7 +14,7 @@ ENV PYTHONUNBUFFERED=1
 COPY requirements.txt .
 RUN pip3 install -r requirements.txt
 
-RUN apt-get autoremove build-essential --purge -y && \
+RUN apt-get autoremove build-essential git --purge -y && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /root/.cache
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,6 @@ mysqlclient==1.4.6
 
 uWSGI==2.0.19.1
 
-https://github.com/Patreon/patreon-python/archive/v0.5.0.zip
+# Patreon doesn't actually have the correct version tagged in their repo and they didn't make it available via pypip.
+# Installing via this specific commit instead of egging master is preferable to prevent sudden breaks
+git+git://github.com/Patreon/patreon-python.git@80c83f018d6bd93b83c188baff727c5e77e01ce6


### PR DESCRIPTION
Updates the package to include the APIv2 changes they made so our linking doesn't randomly break anymore.

Annoyingly, they didn't label the version change and it's not on pypip, so I have to install via a [commit](https://github.com/Patreon/patreon-python/commit/80c83f018d6bd93b83c188baff727c5e77e01ce6). I don't trust egging the master branch even though they abandoned it. 