### PR TITLE
Properly comma separate big numbers

### DIFF
--- a/src/app/templates/bans.html
+++ b/src/app/templates/bans.html
@@ -47,7 +47,7 @@
   <div style="width:100%;">
     <div style="width:295px;display:inline-block;" class="ban-reason"><b class="ban-reason-title">Ban Date:</b> ${ render_dtstring(ban.bantime) }</div>
     <div style="width:315px;display:inline-block;" class="ban-reason"><b class="ban-reason-title">Expire Date:</b> ${ ban.expiration_time ? render_dtstring(ban.expiration_time)  : "Never" }</div>
-    <div style="width:150px;display:inline-block;" class="ban-reason"><b class="ban-reason-title">Round:</b> ${ ban.round_id || "Error!" }</div>
+    <div style="width:150px;display:inline-block;" class="ban-reason"><b class="ban-reason-title">Round:</b> ${ ban.round_id.toLocaleString() || "Error!" }</div>
     <div style="width:175px;display:inline-block;" class="ban-reason"><b class="ban-reason-title">Server:</b> ${ ban.global_ban ? "All" : ban.server_name }</div>
     <div style="width:250px;display:inline-block;" class="ban-reason"><b class="ban-reason-title">Admin:</b> ${ ban.a_ckey }</div>
   </div>

--- a/src/app/templates/home.html
+++ b/src/app/templates/home.html
@@ -21,21 +21,21 @@
       <div class="stat">
         <div class="stat-header">Total Players</div>
         <div v-cloak id="stat-total-players" class="stat-value">
-          ${ server_totals.total_players }
+          ${ server_totals.total_players.toLocaleString() }
         </div>
       </div>
 
       <div class="stat">
         <div class="stat-header">Total Rounds</div>
         <div v-cloak id="stat-total-rounds" class="stat-value">
-          ${ server_totals.total_rounds }
+          ${ server_totals.total_rounds.toLocaleString() }
         </div>
       </div>
 
       <div class="stat">
         <div class="stat-header">Total Connections</div>
         <div v-cloak id="stat-total-connections" class="stat-value">
-          ${ server_totals.total_connections }
+          ${ server_totals.total_connections.toLocaleString() }
         </div>
       </div>
     </div>
@@ -45,7 +45,7 @@
     <div class="progress-bg">
       <div class="progress-bar" :style="{width: budget.percent+'%'}">
         <h3 v-cloak v-if="'income' in budget" class="progress-raised">
-          ${ "$" + budget.income + " / $" + budget.goal }
+          ${ "$" + budget.income.toLocaleString() + " / $" + budget.goal.toLocaleString() }
         </h3>
       </div>
     </div>

--- a/src/app/templates/stats.html
+++ b/src/app/templates/stats.html
@@ -25,13 +25,13 @@
 				<div class="stat">
 					<div class="stat-header">Players</div>
 					<div class="stat-value">
-						${ server_stats[server.id].players }
+						${ server_stats[server.id].players.toLocaleString() }
 					</div>
 				</div>
 				<div class="stat">
 					<div class="stat-header">Admins</div>
 					<div class="stat-value">
-						${ server_stats[server.id].admins }
+						${ server_stats[server.id].admins.toLocaleString() }
 					</div>
 				</div>
 				<div class="stat">
@@ -46,7 +46,7 @@
 				<div class="stat">
 					<div class="stat-header">Round ID</div>
 					<div class="stat-value">
-						${ server_stats[server.id].round_id || "None" }
+						${ server_stats[server.id].round_id ? server_stats[server.id].round_id.toLocaleString() : "None" }
 					</div>
 				</div>
 				<div class="stat">


### PR DESCRIPTION
Since I got rid of the odometers, some numbers have not been comma-separated and are thus hard to read. This PR fixes that and also comma separates some new ones.

![image](https://user-images.githubusercontent.com/24400628/135689698-f26acc30-dfbd-426e-b754-f6ea7d7bfb26.png)
