### PR TITLE
Removes commas from the round-id

### DIFF
--- a/src/app/templates/stats.html
+++ b/src/app/templates/stats.html
@@ -46,7 +46,7 @@
 				<div class="stat">
 					<div class="stat-header">Round ID</div>
 					<div class="stat-value">
-						${ server_stats[server.id].round_id ? server_stats[server.id].round_id.toLocaleString() : "None" }
+						${ server_stats[server.id].round_id ? server_stats[server.id].round_id.toFixed() : "None" }
 					</div>
 				</div>
 				<div class="stat">


### PR DESCRIPTION
Removes commas from the round-id since we don't display it with commas anywhere else.


----

# Before

![image](https://user-images.githubusercontent.com/26130695/151721462-54065067-582a-4e0e-8338-bf24d2516507.png)

# After

![image](https://user-images.githubusercontent.com/26130695/151721459-6d3535f5-5fc9-49f1-8eac-ad103eba6629.png)
