### PR TITLE
Adds the ability to hide servers from the main page

### DIFF
--- a/src/beesite/templates/home.html
+++ b/src/beesite/templates/home.html
@@ -55,11 +55,13 @@
   <div class="links">
     <div class="links-header">Servers</div>
     {% for server in cfg.SERVERS %}
-      {% if server["open"] %}
-        <a class="link" href="/join/{{ server["id"] }}">{{ server["name"] }}</a>
-      {% else %}
-        <a class="link" style="color: var(--bee-gray); text-decoration: line-through;">{{ server["name"] }}</a>
-      {% endif %}
+        {% if not server["hidden"] %}
+            {% if server["open"] %}
+                <a class="link" href="/join/{{ server["id"] }}">{{ server["name"] }}</a>
+            {% else %}
+                <a class="link" style="color: var(--bee-gray); text-decoration: line-through;">{{ server["name"] }}</a>
+            {% endif %}
+        {% endif %}
     {% endfor %}
   </div>
 


### PR DESCRIPTION
Servers explicitly defined as being "hidden" will not show up on the front page, but their join links will still work. Servers without `hidden` set are assumed to be public.

Example hidden entry:

```yml
- id: 'example'
  aliases:
    - 'example'
  name: 'BeeStation Sample Server'
  nickname: 'Example'
  host: 'example.server.com'
  port: 1234
  open: hidden
  hidden: true
  color: '0, 150, 0'
  rules_url: 'https://wiki.beestation13.com/view/Rules'
```